### PR TITLE
Rely on lower versions

### DIFF
--- a/.install_deps
+++ b/.install_deps
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $DEPS_VERSION = "OLD" ]]; then
+    pip install jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
+    pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
+else
+    pip install --upgrade --pre -r requirements.txt
+    pip install --upgrade --pre -r test_requirements.txt
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,6 @@ script:
 matrix:
   fast_finish: true
   include:
-  - name: "Python 3.6 Latest Dependencies"
-    python: "3.6"
-    env: DEPS_VERSION=NEW
-  - name: "Python 3.6 Oldest Dependencies"
-    python: "3.6"
-    env: DEPS_VERSION=OLD
-  - name: "Python 3.7 Latest Dependencies"
-    python: "3.7"
-    env: DEPS_VERSION=NEW
   - name: "Python 3.7 Oldest Dependencies"
     python: "3.7"
     env: DEPS_VERSION=OLD
@@ -35,3 +26,12 @@ matrix:
   - name: "Python Nightly Oldest Dependencies"
     python: nightly
     env: DEPS_VERSION=OLD
+  - name: "Python 3.6 Latest Dependencies"
+    python: "3.6"
+    env: DEPS_VERSION=NEW
+  - name: "Python 3.6 Oldest Dependencies"
+    python: "3.6"
+    env: DEPS_VERSION=OLD
+  - name: "Python 3.7 Latest Dependencies"
+    python: "3.7"
+    env: DEPS_VERSION=NEW

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: false
 cache:
   - pip
 
+dist: xenial
+
 before_install:
   - set -e
 
 install:
-  - pip install --upgrade pip
-  - pip install --upgrade --pre -r requirements.txt
-  - pip install --upgrade --pre -r test_requirements.txt
+  - bash .install_deps
 
 script:
   - pytest --cov=samlauthenticator --cov-report term-missing
@@ -17,6 +17,21 @@ script:
 matrix:
   fast_finish: true
   include:
-    - python: 3.6
-    - python: 3.7
-      dist: xenial
+  - name: "Python 3.6 Latest Dependencies"
+    python: "3.6"
+    env: DEPS_VERSION=NEW
+  - name: "Python 3.6 Oldest Dependencies"
+    python: "3.6"
+    env: DEPS_VERSION=OLD
+  - name: "Python 3.7 Latest Dependencies"
+    python: "3.7"
+    env: DEPS_VERSION=NEW
+  - name: "Python 3.7 Oldest Dependencies"
+    python: "3.7"
+    env: DEPS_VERSION=OLD
+  - name: "Python Nightly Latest Dependencies"
+    python: nightly
+    env: DEPS_VERSION=NEW
+  - name: "Python Nightly Oldest Dependencies"
+    python: nightly
+    env: DEPS_VERSION=OLD

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-jupyterhub>=0.9.6
-lxml>=4.3.3
+jupyterhub>=0.9.0
+lxml>=4.2.1
 signxml>=2.6.0
-tornado>=6.0.2
-traitlets>=4.3.2
 pytz>=2019.1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
-pytest>=4.4.0
+pytest>=4.0.0
 pytest-asyncio>=0.10.0
-pytest-cov>=2.6.1
+pytest-cov>=2.0.0


### PR DESCRIPTION
We could force users to have the latest-and-greatest code
as of release of the Authenticator, but it would be more
courteous to require the oldest version that we could
support and then change these version requirements on
major-point releases.

Partially completes #7 - don't know how much more
work is needed after this. I think it's ok to go down
to the "most major" point version in SemVer
(so if there has been a major release, down to
XXX.0.0, if there has been a minor release,
down to XX.YY.0, if there has been a bugfix,
down to XX.YY.ZZ).

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Tom Kelley <distortedsignal@gmail.com>
