### PR TITLE
Provide SP metadata from jupyterhub.

### DIFF
--- a/.install_deps
+++ b/.install_deps
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $DEPS_VERSION = "OLD" ]]; then
-    pip install jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
+    pip install jinja2==1.0 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
 else
     pip install --upgrade --pre -r requirements.txt

--- a/.install_deps
+++ b/.install_deps
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $DEPS_VERSION = "OLD" ]]; then
-    pip install Jinja2==2.0 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
+    pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
 else
     pip install --upgrade --pre -r requirements.txt

--- a/.install_deps
+++ b/.install_deps
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $DEPS_VERSION = "OLD" ]]; then
-    pip install jinja2==1.0 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
+    pip install Jinja2==2.0 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
 else
     pip install --upgrade --pre -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2>=2.0
+Jinja2>=2.4
 jupyterhub>=0.9.0
 lxml>=4.2.1
 signxml>=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jinja2>=1.0
+Jinja2>=2.0
 jupyterhub>=0.9.0
 lxml>=4.2.1
 signxml>=2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+jinja2>=1.0
 jupyterhub>=0.9.0
 lxml>=4.2.1
 signxml>=2.6.0


### PR DESCRIPTION
Usually, SAML Service Providers supply metadata so that
IdPs can easily interoperate with the individual services.
After a request from @guillaumeeb, I thought that it would
be a good plan for the Authenticator to also supply this
metadata.

This is a pretty early cut of this ability, but I think
it's a good start. I'll try using this with one of the
IdPs that my company has set up and make changes to this
branch. I think this completes #5.

Currently, if the jupyterhub is set up on localhost at
port 8000, the returned XML looks like this:

```xml
<?xml version="1.0"?>
<EntityDescriptor
 entityID="http://localhost:8000"
 xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
 xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
 xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
    <SPSSODescriptor
     AuthnRequestsSigned="false"
     protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
        <NameIDFormat>
            urn:oasis:names:tc:SAML:2.0:nameid-format:transient
        </NameIDFormat>
        <AssertionConsumerService
         Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
         Location="http://localhost:8000/hub/login"/>
    </SPSSODescriptor>
</EntityDescriptor>
```

Obviously this isn't as useful as it could be. There are
currently issues open on the Authenticator to support
fields such as SP OrganizationName and
OrganizationDisplayName. I want to make this change small
enough to be comprehensible.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Tom Kelley <distortedsignal@gmail.com>
