### PR TITLE
Add create_system_users config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Configure one of the accepted metadata sources. The SAMLAuthenticator can get me
 
 This is all the configuration the Authenticator _usually_ requires, but there are more configuration options to go through.
 
+#### Optional Configuration
+
 If the user that should be created and logged in from a given SAML Response is _not_ specified by the NameID element in the SAML Assertion, an alternate field can be specified. Replace the `xpath_username_location` field in the `SAMLAuthenticator` with an XPath that points to the desired field in the SAML Assertion. Note that this value must be able to be compiled to an XPath by Python's `lxml` module. The namespaces that will be present for this XPath are as follows:
 
 ```py
@@ -85,6 +87,8 @@ The following two configurations are _usually_ on logout handlers, but because S
 If the user's servers should be shut down when they logout, set `shutdown_on_logout` to `True`. This stops all servers that the user was running as part of their session. It is a somewhat dangerous to set this option to `True` because a user may not be done with computations that they are running on those servers.
 
 The SAMLAuthenticator _usually_ attempts to forward users to the SLO URI set in the SAML Metadata. If this is not the desired behavior for whatever reason, set `slo_forward_on_logout` to `False`. This will change the page the user is forwarded to on logout from the page specified in the xml metadata to the standard jupyterhub logout page.
+
+SAMLAuthenticator creates system users by default on successful authentication. If you are running JupyterHub as a non-root user, you may need to turn off this functionality by setting `create_system_users` to `False`.
 
 #### Example Configurations
 
@@ -138,6 +142,9 @@ c.SAMLAuthenticator.acs_endpoint_url = 'https://10.0.31.2:8000/hub/login'
 c.SAMLAuthenticator.organization_name = 'My Org'
 c.SAMLAuthenticator.organization_display_name = '''My Org's Display Name'''
 c.SAMLAuthenticator.organization_url = 'https://myorg.com'
+
+# Turn off system user creation on authentication
+c.SAMLAuthenticator.create_system_users = False
 ```
 
 ## Developing and Contributing

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -247,6 +247,16 @@ class SAMLAuthenticator(Authenticator):
         A URL that uniquely identifies the organization.
         '''
     )
+    create_system_users = Bool(
+        default_value=True,
+        allow_none=False,
+        config=True,
+        help='''
+        When True, SAMLAuthenticator will create system users
+        on user authentication if they don't exist already.
+        Default value is True.
+        '''
+    )
 
     def _get_metadata_from_file(self):
         with open(self.metadata_filepath, 'r') as saml_metadata:
@@ -531,7 +541,10 @@ class SAMLAuthenticator(Authenticator):
         if self.validate_username(username) and \
                 self.check_blacklist(username) and \
                 self.check_whitelist(username):
-            return self._optional_user_add(username)
+            if self.create_system_users:
+                return self._optional_user_add(username)
+
+            return True
 
         return False
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -497,6 +497,15 @@ class TestCreateUser(unittest.TestCase):
 
         a._optional_user_add.assert_not_called()
 
+    def test_create_system_users_option(self):
+        a = SAMLAuthenticator()
+        a.create_system_users = False
+        a._optional_user_add = MagicMock()
+
+        assert a._check_username_and_add_user('bluedata')
+
+        a._optional_user_add.assert_not_called()
+
 
 class TestAuthenticate(unittest.TestCase):
     def _confirm_tom(self, saml_data, mock_datetime, mock_pwd):


### PR DESCRIPTION
Signed-off-by: Matt Wilber <mattwilber94@gmail.com>

Adds a `create_system_users` config option, which is `True` by default, and causes system users to be created upon successful user authentication (existing behavior). When set to `False`, these system users will not be created.

I did not add myself to the `ATTRIBUTION.md` document, feel free to add me!

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Matt Wilber <mattwilber94@gmail.com>
