### PR TITLE
Fix new python old dependencies

### DIFF
--- a/.install_deps
+++ b/.install_deps
@@ -3,7 +3,7 @@
 if [[ $DEPS_VERSION = "OLD" ]]; then
     pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
-else if [[ $DEPS_VERSION = "POST_3.8" ]]; then
+else if [[ $DEPS_VERSION = "AFTER38" ]]; then
     pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.3.4 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
 else

--- a/.install_deps
+++ b/.install_deps
@@ -3,7 +3,7 @@
 if [[ $DEPS_VERSION = "OLD" ]]; then
     pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
-else if [[ $DEPS_VERSION = "AFTER38" ]]; then
+elif [[ $DEPS_VERSION = "AFTER38" ]]; then
     pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.3.4 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
 else

--- a/.install_deps
+++ b/.install_deps
@@ -3,6 +3,9 @@
 if [[ $DEPS_VERSION = "OLD" ]]; then
     pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.2.1 signxml==2.6.0 pytz==2019.1
     pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
+else if [[ $DEPS_VERSION = "POST_3.8" ]]; then
+    pip install Jinja2==2.4 jupyterhub==0.9.0 lxml==4.3.4 signxml==2.6.0 pytz==2019.1
+    pip install pytest==4.0.0 pytest-asyncio==0.10.0 pytest-cov==2.0.0;
 else
     pip install --upgrade --pre -r requirements.txt
     pip install --upgrade --pre -r test_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     env: DEPS_VERSION=NEW
   - name: "Python Nightly Oldest Dependencies"
     python: nightly
-    env: DEPS_VERSION=OLD
+    env: DEPS_VERSION=POST_3.8
   - name: "Python 3.6 Latest Dependencies"
     python: "3.6"
     env: DEPS_VERSION=NEW

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     env: DEPS_VERSION=NEW
   - name: "Python Nightly Oldest Dependencies"
     python: nightly
-    env: DEPS_VERSION=POST_3.8
+    env: DEPS_VERSION="POST_3.8"
   - name: "Python 3.6 Latest Dependencies"
     python: "3.6"
     env: DEPS_VERSION=NEW

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     env: DEPS_VERSION=NEW
   - name: "Python Nightly Oldest Dependencies"
     python: nightly
-    env: DEPS_VERSION="POST_3.8"
+    env: DEPS_VERSION=AFTER38
   - name: "Python 3.6 Latest Dependencies"
     python: "3.6"
     env: DEPS_VERSION=NEW


### PR DESCRIPTION
Prior to this PR, the "latest python, old dependencies" build was failing because lxml was being difficult ([see here for example](https://travis-ci.com/bluedatainc/jupyterhub-samlauthenticator/jobs/213825938)). This PR introduces a new DEPS_VERSION named "AFTER38" which should be the oldest dependencies available... when a user updates their system to Python 3.8. Was this wholly unnecessary? Probably. Am I glad that I did it? Yes.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Thomas Kelley <distortedsignal@gmail.com>
