### PR TITLE
Add customization of nameid format paramter in SP metadata

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -200,6 +200,20 @@ class SAMLAuthenticator(Authenticator):
         'https://10.0.31.2:8000'
         '''
     )
+    nameid_format = Unicode(
+        default_value='urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
+        allow_none=True,
+        config=True,
+        help='''
+        The nameId format to set in the Jupyter SAML Metadata.
+        Detaults to transient nameid-format, but other values such as
+        urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress or
+        urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+        are available. See section 8.3 of the spec
+        http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf
+        for more details.
+        '''
+    )
     acs_endpoint_url = Unicode(
         default_value='',
         allow_none=True,
@@ -651,7 +665,7 @@ class SAMLAuthenticator(Authenticator):
             AuthnRequestsSigned="false"
             protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
         <NameIDFormat>
-            urn:oasis:names:tc:SAML:2.0:nameid-format:transient
+            {{ nameIdFormat }}
         </NameIDFormat>
         <AssertionConsumerService
                 Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
@@ -671,6 +685,7 @@ class SAMLAuthenticator(Authenticator):
 
         xml_template = Template(metadata_text)
         return xml_template.render(entityId=entity_id,
+                                   nameIdFormat=authenticator_self.nameid_format,
                                    entityLocation=acs_endpoint_url,
                                    organizationMetadata=org_metadata_elem)
 

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -686,6 +686,24 @@ class TestMakeSPMetadata(unittest.TestCase):
     </SPSSODescriptor>
     
 </EntityDescriptor>'''
+    full_sp_meta_nameid_format = '''<?xml version="1.0"?>
+<EntityDescriptor
+        entityID="https://localhost:8000"
+        xmlns="urn:oasis:names:tc:SAML:2.0:metadata"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+    <SPSSODescriptor
+            AuthnRequestsSigned="false"
+            protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+        <NameIDFormat>
+            urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
+        </NameIDFormat>
+        <AssertionConsumerService
+                Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                Location="https://localhost:8000/hub/login"/>
+    </SPSSODescriptor>
+    
+</EntityDescriptor>'''
     full_sp_meta_org_name = '''<?xml version="1.0"?>
 <EntityDescriptor
         entityID="https://localhost:8000"
@@ -762,6 +780,15 @@ class TestMakeSPMetadata(unittest.TestCase):
 
         assert a._make_sp_metadata(mock_handler_self) == self.full_sp_meta_org_name
 
+    def test_make_full_metadata_nameid_format(self):
+        a = SAMLAuthenticator()
+        a.nameid_format = 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent'
+
+        mock_handler_self = MagicMock()
+        mock_handler_self.request.protocol = 'https'
+        mock_handler_self.request.host = 'localhost:8000'
+
+        assert a._make_sp_metadata(mock_handler_self) == self.full_sp_meta_nameid_format
 
 class TestGetHandlers(unittest.TestCase):
     expected_handler_paths = ['/login', '/hub/login', '/logout', '/hub/logout', '/metadata', '/hub/metadata']


### PR DESCRIPTION
This PR allows customisation of nameID format parameter in the metadata file.
 
```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Benoit Perroud
