### PR TITLE
Add customization of user creation binary to call for a new user

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -257,6 +257,18 @@ class SAMLAuthenticator(Authenticator):
         Default value is True.
         '''
     )
+    create_system_user_binary = Unicode(
+        default_value='useradd',
+        allow_none=True,
+        config=True,
+        help='''
+        When SAMLAuthenticator create system user (also called "just in time user provisioning")
+        it calls the binary specified in this property in a subprocess to perform the user creation.
+        Default value is useradd, but any other existing binary in the PATH would be called
+        followed by the username to actually add.
+        The binary must follow the same return code than useradd, i.e. return 0 in case of success.
+        '''
+    )
 
     def _get_metadata_from_file(self):
         with open(self.metadata_filepath, 'r') as saml_metadata:
@@ -535,7 +547,7 @@ class SAMLAuthenticator(Authenticator):
         except KeyError:
             # Return the `not` here because a 0 return indicates success and I want to
             # say something like "if adding the user is successful, return username"
-            return not subprocess.call(['useradd', username])
+            return not subprocess.call([self.create_system_user_binary, username])
 
     def _check_username_and_add_user(self, username):
         if self.validate_username(username) and \


### PR DESCRIPTION
Add customization of user creation binary to call when a new user is properly authenticated

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Benoit Perroud