### PR TITLE
Shuffle matrix order, add 3.8 to matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,23 +21,29 @@ after_success:
 matrix:
   fast_finish: true
   include:
+  - name: "Python 3.8 Oldest Dependencies"
+    python: "3.8"
+    env: DEPS_VERSION=AFTER38
+  - name: "Python 3.8 Latest Dependencies"
+    python: "3.8"
+    env: DEPS_VERSION=NEW
   - name: "Python 3.7 Oldest Dependencies"
     python: "3.7"
     env: DEPS_VERSION=OLD
-  - name: "Python Nightly Latest Dependencies"
-    python: nightly
-    env: DEPS_VERSION=NEW
-  - name: "Python Nightly Oldest Dependencies"
-    python: nightly
-    env: DEPS_VERSION=AFTER38
-  - name: "Python 3.6 Latest Dependencies"
-    python: "3.6"
+  - name: "Python 3.7 Latest Dependencies"
+    python: "3.7"
     env: DEPS_VERSION=NEW
   - name: "Python 3.6 Oldest Dependencies"
     python: "3.6"
     env: DEPS_VERSION=OLD
-  - name: "Python 3.7 Latest Dependencies"
-    python: "3.7"
+  - name: "Python 3.6 Latest Dependencies"
+    python: "3.6"
+    env: DEPS_VERSION=NEW
+  - name: "Python Nightly Oldest Dependencies"
+    python: nightly
+    env: DEPS_VERSION=AFTER38
+  - name: "Python Nightly Latest Dependencies"
+    python: nightly
     env: DEPS_VERSION=NEW
   allow_failures:
   - python: nightly


### PR DESCRIPTION
Add Python 3.8 to travis build matrix, reshuffle matrix so it reads better.

This should wait until travis gets an official image for 3.8 to merge. According to [PEP 569](https://www.python.org/dev/peps/pep-0569/), that should happen sometime after 2019-10-21.

This isn't really a "feature", so I'm not going to assign it to a release.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Thomas Kelley <distortedsignal@gmail.com>
