### PR TITLE
Use xpath's string() to convert node-set to string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ venv/
 *.egg-info/
 build/
 dist/
+
+# IDE settings
+.vscode

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ c.SAMLAuthenticator.metadata_filepath = '/etc/jupyterhub/metadata.xml'
 
 # A field was placed in the SAML Response that contains the user's first name and last name separated by a period.
 # Let's use that for the username.
-c.SAMLAuthenticator.xpath_username_location = 'string(//saml:Attribute[@Name="DottedName"]/saml:AttributeValue/text())'
+c.SAMLAuthenticator.xpath_username_location = '//saml:Attribute[@Name="DottedName"]/saml:AttributeValue/text()'
 
 # The IdP is sending the SAML Response in a field named 'R'
 c.SAMLAuthenticator.login_post_field = 'R'

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ c.SAMLAuthenticator.metadata_filepath = '/etc/jupyterhub/metadata.xml'
 
 # A field was placed in the SAML Response that contains the user's first name and last name separated by a period.
 # Let's use that for the username.
-c.SAMLAuthenticator.xpath_username_location = '//saml:Attribute[@Name="DottedName"]/saml:AttributeValue/text()'
+c.SAMLAuthenticator.xpath_username_location = 'string(//saml:Attribute[@Name="DottedName"]/saml:AttributeValue/text())'
 
 # The IdP is sending the SAML Response in a field named 'R'
 c.SAMLAuthenticator.login_post_field = 'R'

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -542,7 +542,7 @@ class SAMLAuthenticator(Authenticator):
 
         if type(xpath_result) is str:
             return xpath_result
-	if type(xpath_result) is list:
+        if type(xpath_result) is list and len(xpath_result) > 0:
             return xpath_result[0]
 
         self.log.warning('Could not find name from name XPath')

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -76,7 +76,7 @@ class SAMLAuthenticator(Authenticator):
         '''
     )
     xpath_username_location = Unicode(
-        default_value='//saml:NameID/text()',
+        default_value='string(//saml:NameID/text())',
         allow_none=True,
         config=True,
         help='''
@@ -92,6 +92,7 @@ class SAMLAuthenticator(Authenticator):
             'saml' : 'urn:oasis:names:tc:SAML:2.0:assertion',
             'samlp': 'urn:oasis:names:tc:SAML:2.0:protocol'
         }
+	Note that the xpath should return a string, not a node-set.
         '''
     )
     login_post_field = Unicode(
@@ -281,7 +282,7 @@ class SAMLAuthenticator(Authenticator):
         Default value is 'useradd'.
         This can be set to any binary in the host machine's PATH or a full path to an alternate
         binary not in the host's path. This binary MUST accpet calls of the form
-        "$\{binary_name\} $\{user_name\}" and exit with a status of zero on valid user addition or
+        "${binary_name} ${user_name}" and exit with a status of zero on valid user addition or
         a non-zero status in the failure case.
         '''
     )
@@ -539,11 +540,11 @@ class SAMLAuthenticator(Authenticator):
 
         xpath_fun = xpath_with_namespaces(self.xpath_username_location)
         xpath_result = xpath_fun(signed_xml)
+
         if xpath_result:
-            return xpath_result[0]
+            return xpath_result
 
         self.log.warning('Could not find name from name XPath')
-
         return None
 
     def _get_username_from_saml_doc(self, signed_xml, decoded_saml_doc):

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -540,7 +540,7 @@ class SAMLAuthenticator(Authenticator):
         xpath_fun = xpath_with_namespaces(self.xpath_username_location)
         xpath_result = xpath_fun(signed_xml)
 
-        if type(xpath_result) is str:
+        if isinstance(xpath_result, etree._ElementUnicodeResult):
             return xpath_result
         if type(xpath_result) is list and len(xpath_result) > 0:
             return xpath_result[0]

--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -76,7 +76,7 @@ class SAMLAuthenticator(Authenticator):
         '''
     )
     xpath_username_location = Unicode(
-        default_value='string(//saml:NameID/text())',
+        default_value='//saml:NameID/text()',
         allow_none=True,
         config=True,
         help='''
@@ -92,7 +92,6 @@ class SAMLAuthenticator(Authenticator):
             'saml' : 'urn:oasis:names:tc:SAML:2.0:assertion',
             'samlp': 'urn:oasis:names:tc:SAML:2.0:protocol'
         }
-	Note that the xpath should return a string, not a node-set.
         '''
     )
     login_post_field = Unicode(
@@ -541,8 +540,10 @@ class SAMLAuthenticator(Authenticator):
         xpath_fun = xpath_with_namespaces(self.xpath_username_location)
         xpath_result = xpath_fun(signed_xml)
 
-        if xpath_result:
+        if type(xpath_result) is str:
             return xpath_result
+	if type(xpath_result) is list:
+            return xpath_result[0]
 
         self.log.warning('Could not find name from name XPath')
         return None

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -405,6 +405,16 @@ class TestGetUsername(unittest.TestCase):
         assert 'Bluedata' == a._get_username_from_saml_etree(self.response_etree)
         assert 'Bluedata' == a._get_username_from_saml_doc(self.verified_signed_xml, self.response_etree)
 
+        a.xpath_username_location = 'string({})'.format(a.xpath_username_location)
+        assert 'Bluedata' == a._get_username_from_saml_etree(self.verified_signed_xml)
+        assert 'Bluedata' == a._get_username_from_saml_etree(self.response_etree)
+        assert 'Bluedata' == a._get_username_from_saml_doc(self.verified_signed_xml, self.response_etree)
+
+        a.xpath_username_location = 'substring-before({}, "data")'.format(a.xpath_username_location)
+        assert 'Blue' == a._get_username_from_saml_etree(self.verified_signed_xml)
+        assert 'Blue' == a._get_username_from_saml_etree(self.response_etree)
+        assert 'Blue' == a._get_username_from_saml_doc(self.verified_signed_xml, self.response_etree)
+
     def test_get_username_no_nameid(self):
         tampered_assertion_etree = etree.fromstring(test_constants.tampered_assertion_no_nameid)
         tampered_response_etree  = etree.fromstring(test_constants.tampered_response_no_nameid)


### PR DESCRIPTION
To get username from SAML response, right now we execute an xpath expression, expect the results as a nodeset, and then return the first item in the nodeset. This behavior can be done completely in xpath using https://www.w3.org/TR/1999/REC-xpath-19991116/#function-string

This diff expects the xpath_username_location expression to be written in that way, so we could just return the whole result.

This fixes #46 
```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Thi Duong Nguyen (thiduongnguyen@gmail.com)
