### PR TITLE
Minor refactor on role/group code.

### DIFF
--- a/samlauthenticator/samlauthenticator.py
+++ b/samlauthenticator/samlauthenticator.py
@@ -217,7 +217,7 @@ class SAMLAuthenticator(Authenticator):
         config=True,
         help='''
         The nameId format to set in the Jupyter SAML Metadata.
-        Detaults to transient nameid-format, but other values such as
+        Defaults to transient nameid-format, but other values such as
         urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress or
         urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
         are available. See section 8.3 of the spec


### PR DESCRIPTION
This is a minor refactor on the role/group code, and a little on the code that returns the username as well.

I was thinking about this code over the weekend, and I realized that, even if there was no way for the user to log in via groups, we would still run the XPath to get their groups from the SAML Response. I would prefer that we only run the XPath if we have to.

There was some collateral damage to the final code that checks if the user needs to be created in the system and returns the username.

```
Developer Certificate of Origin Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors. 660 York Street, Suite 102, San Francisco, CA 94110 USA

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or

(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.

(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
```

Signed-off-by: Thomas Kelley <distortedsignal@gmail.com>
